### PR TITLE
Allow configuring seed at runtime

### DIFF
--- a/include/rapidcheck/detail/Configuration.h
+++ b/include/rapidcheck/detail/Configuration.h
@@ -53,6 +53,9 @@ std::string configToString(const Configuration &config);
 /// keys that differ from the default configuration.
 std::string configToMinimalString(const Configuration &config);
 
+/// Set the seed for the global configuration
+void setGlobalSeed(uint64_t seed);
+
 /// Returns the global configuration.
 const Configuration &configuration();
 

--- a/src/detail/Configuration.cpp
+++ b/src/detail/Configuration.cpp
@@ -228,17 +228,21 @@ Configuration loadConfiguration() {
             << std::endl;
   return config;
 }
-static Configuration g_config = loadConfiguration();
+
+Configuration &getSingleConfiguration() {
+  static Configuration config = loadConfiguration();
+  return config;
+}
 
 } // namespace
 
 void setGlobalSeed(uint64_t seed) {
   std::cerr << "Using new global seed: " << seed << std::endl;
-  g_config.testParams.seed = seed;
+  getSingleConfiguration().testParams.seed = seed;
 }
 
 const Configuration &configuration() {
-  return g_config;
+  return getSingleConfiguration();
 }
 
 } // namespace detail

--- a/src/detail/Configuration.cpp
+++ b/src/detail/Configuration.cpp
@@ -228,12 +228,17 @@ Configuration loadConfiguration() {
             << std::endl;
   return config;
 }
+static Configuration g_config = loadConfiguration();
 
 } // namespace
 
+void setGlobalSeed(uint64_t seed) {
+  std::cerr << "Using new global seed: " << seed << std::endl;
+  g_config.testParams.seed = seed;
+}
+
 const Configuration &configuration() {
-  static const Configuration config = loadConfiguration();
-  return config;
+  return g_config;
 }
 
 } // namespace detail


### PR DESCRIPTION
Title says all, I needed a way to set the seed value at runtime as we want to control the seed value on a test-case basis at runtime. I checked and the seed value is queried between each test run, so this change should be safe. Note that this is not true of every substate of the configuration, so allowing mutation of the whole config state would be dubious.